### PR TITLE
Merge pre-2000 history into data/speakers.yaml 

### DIFF
--- a/data/speakers.yaml
+++ b/data/speakers.yaml
@@ -1382,3 +1382,8 @@
     title: Typesetting with TeX/LaTeX
     date: 2000-01-13
     email: lovering@boulder.nist.gov
+- talk:
+    speaker: 
+    title: Typesetting with TeX/LaTeX
+    date: 2000-01-13
+    email: lovering@boulder.nist.gov

--- a/data/speakers.yaml
+++ b/data/speakers.yaml
@@ -1383,7 +1383,6 @@
     date: 2000-01-13
     email: lovering@boulder.nist.gov
 - talk:
-    speaker: 
-    title: Typesetting with TeX/LaTeX
-    date: 2000-01-13
-    email: lovering@boulder.nist.gov
+    speaker: Wayde Allen, NIST
+    title: Boulder Linux User's Group (BLUG) Kick-off Meeting
+    date: 1996-12-11


### PR DESCRIPTION
Many of our meetings, back to 2000, are at http://lug.boulder.co.us/meetings.html
via the file data/speakers.yaml.

Archive.org has more history of meetings, from the kick-off meeting in 1996, until 1999, which can be merged in. See e.g.
https://web.archive.org/web/19990422022231/http://lug.boulder.co.us/presentations.html

This replaces issue #4 
